### PR TITLE
misc:修正mock数据，同步数据文件地址（js/json）

### DIFF
--- a/src/modules/data/sync_data.js
+++ b/src/modules/data/sync_data.js
@@ -54,7 +54,7 @@ export default {
         throw new Error();
       }
     } catch (err) {
-      log.error(`Sync mock data parse error, check your template .json file, url: ${path}.json`);
+      log.error(`Sync mock data parse error, check your template .json file, url: ${pageDataPath}.json`);
     }
     pageData = pageData || {};
 
@@ -73,9 +73,9 @@ export default {
     }
 
     try {
-      data = processData(path, data, ctx);
+      data = processData(pageDataPath, data, ctx);
     } catch (err) {
-      log.error(`Sync mock data parse error, check your template .js file, url: ${path}.js`);
+      log.error(`Sync mock data parse error, check your template .js file, url: ${pageDataPath}.js`);
     }
 
     return data || {};


### PR DESCRIPTION
同步数据js文件没有渲染，经排查，发现对应js文件没有执行到，是因为执行js文件的时候，路径是错的（格式化之前的路径），也没有抛出错误